### PR TITLE
[Refactor] JPA 연관관계 변화로 인한 전체적인 코드 리팩토링

### DIFF
--- a/src/main/java/catchtable/cooking/controller/RestaurantController.java
+++ b/src/main/java/catchtable/cooking/controller/RestaurantController.java
@@ -1,15 +1,16 @@
 package catchtable.cooking.controller;
 
-import catchtable.cooking.dto.*;
+import catchtable.cooking.dto.CommonResponse;
+import catchtable.cooking.dto.RestaurantCreateParam;
+import catchtable.cooking.dto.RestaurantCreateRequest;
+import catchtable.cooking.dto.RestaurantItemResponse;
 import catchtable.cooking.exception.Code;
-import catchtable.cooking.persist.domain.Restaurant;
 import catchtable.cooking.service.RestaurantService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -19,19 +20,11 @@ public class RestaurantController {
     private final RestaurantService restaurantService;
 
     @GetMapping("/restaurants")
-    public CommonResponse<?> readEntireRestaurant(@RequestParam(value = "keyword", required = false) String keyword) {
+    public CommonResponse<?> readRestaurants(@RequestParam(value = "keyword", required = false) String keyword) {
 
-        List<Restaurant> restaurantList = restaurantService.readEntireRestaurant(keyword);
-        List<RestaurantItemResponse> restaurantItemResponse = restaurantList.stream()
-                .map(restaurant -> new RestaurantItemResponse(
-                        restaurant.getName(),
-                        restaurant.getPhoneNumber(),
-                        restaurant.getAddress(),
-                        restaurant.getMenus(),
-                        restaurant.getReviews()
-                )).collect(Collectors.toList());
+        List<RestaurantItemResponse> restaurantItemResponses = restaurantService.readRestaurants(keyword);
 
-        return CommonResponse.of(restaurantItemResponse);
+        return CommonResponse.of(restaurantItemResponses);
     }
 
     @PostMapping("/restaurants")
@@ -43,8 +36,8 @@ public class RestaurantController {
 
     @GetMapping("/restaurants/{id}")
     public CommonResponse<?> readRestaurant(@PathVariable Long id) {
-        Restaurant restaurant = restaurantService.readRestaurant(id);
-        return CommonResponse.of(restaurant);
+        RestaurantItemResponse restaurantItemResponse = restaurantService.readRestaurant(id);
+        return CommonResponse.of(restaurantItemResponse);
     }
 
 

--- a/src/main/java/catchtable/cooking/controller/ReviewController.java
+++ b/src/main/java/catchtable/cooking/controller/ReviewController.java
@@ -4,13 +4,10 @@ import catchtable.cooking.dto.CommonResponse;
 import catchtable.cooking.dto.ReviewCreateParam;
 import catchtable.cooking.dto.ReviewCreateRequest;
 import catchtable.cooking.exception.Code;
-import catchtable.cooking.persist.domain.Review;
 import catchtable.cooking.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -19,12 +16,6 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    @GetMapping("/restaurants/{id}/reviews")
-    public CommonResponse<?> readReviews(@PathVariable Long id) {
-        List<Review> reviews = reviewService.readReviews(id);
-
-        return CommonResponse.of(reviews);
-    }
 
     @PostMapping("/restaurants/{id}/reviews")
     public CommonResponse<?> postReview(@PathVariable Long id, @RequestBody ReviewCreateRequest reviewCreateRequest) {

--- a/src/main/java/catchtable/cooking/dto/RestaurantCreateParam.java
+++ b/src/main/java/catchtable/cooking/dto/RestaurantCreateParam.java
@@ -1,6 +1,5 @@
 package catchtable.cooking.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 @Data
@@ -12,17 +11,14 @@ public class RestaurantCreateParam {
 
     private String name;
 
-    private String phoneNumber;
-
     private String address;
 
-    private String menu;
+    private String phoneNumber;
 
     public RestaurantCreateParam(RestaurantCreateRequest request) {
         this.name = request.getName();
         this.phoneNumber = request.getPhoneNumber();
         this.address = request.getAddress();
-        this.menu = request.getMenu();
     }
 
 }

--- a/src/main/java/catchtable/cooking/dto/RestaurantCreateRequest.java
+++ b/src/main/java/catchtable/cooking/dto/RestaurantCreateRequest.java
@@ -1,19 +1,16 @@
 package catchtable.cooking.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
-@Getter
 @NoArgsConstructor
 public class RestaurantCreateRequest {
 
     private String name;
 
-    private String phoneNumber;
-
     private String address;
 
-    private String menu;
+    private String phoneNumber;
 
 }

--- a/src/main/java/catchtable/cooking/dto/RestaurantItemResponse.java
+++ b/src/main/java/catchtable/cooking/dto/RestaurantItemResponse.java
@@ -1,7 +1,9 @@
 package catchtable.cooking.dto;
 
 import catchtable.cooking.persist.domain.Menu;
+import catchtable.cooking.persist.domain.Reservation;
 import catchtable.cooking.persist.domain.Review;
+import catchtable.cooking.persist.domain.Waiting;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,13 +20,16 @@ public class RestaurantItemResponse {
 
     private String name;
 
-    private String phoneNumber;
-
     private String address;
+
+    private String phoneNumber;
 
     private List<Menu> menus = new ArrayList<>();
 
     private List<Review> reviews = new ArrayList<>();
 
+    private List<Waiting> waitings = new ArrayList<>();
+
+    private List<Reservation> reservations = new ArrayList<>();
 
 }

--- a/src/main/java/catchtable/cooking/persist/domain/Menu.java
+++ b/src/main/java/catchtable/cooking/persist/domain/Menu.java
@@ -1,12 +1,11 @@
 package catchtable.cooking.persist.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -20,6 +19,7 @@ public class Menu extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "restaurant_id")
+    @JsonIgnore
     private Restaurant restaurant;
 
     private String name;

--- a/src/main/java/catchtable/cooking/persist/domain/Restaurant.java
+++ b/src/main/java/catchtable/cooking/persist/domain/Restaurant.java
@@ -35,7 +35,6 @@ public class Restaurant extends BaseTimeEntity {
 
     private LocalDateTime deletedDateTime;
 
-
     public Restaurant(RestaurantCreateRequest restaurant) {
         this.name = restaurant.getName();
         this.phoneNumber = restaurant.getPhoneNumber();

--- a/src/main/java/catchtable/cooking/persist/repository/MemberRepository.java
+++ b/src/main/java/catchtable/cooking/persist/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package catchtable.cooking.persist.repository;
+
+import catchtable.cooking.persist.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/catchtable/cooking/persist/repository/MenuRepository.java
+++ b/src/main/java/catchtable/cooking/persist/repository/MenuRepository.java
@@ -1,14 +1,14 @@
 package catchtable.cooking.persist.repository;
 
-import catchtable.cooking.persist.domain.Review;
+import catchtable.cooking.persist.domain.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface MenuRepository extends JpaRepository<Menu, Long> {
 
-    List<Review> findAllByRestaurantId(Long restaurantId);
+    List<Menu> findAllByRestaurantId(Long restaurantId);
 
 }

--- a/src/main/java/catchtable/cooking/persist/repository/ReservationRepository.java
+++ b/src/main/java/catchtable/cooking/persist/repository/ReservationRepository.java
@@ -1,14 +1,14 @@
 package catchtable.cooking.persist.repository;
 
-import catchtable.cooking.persist.domain.Review;
+import catchtable.cooking.persist.domain.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-    List<Review> findAllByRestaurantId(Long restaurantId);
+    List<Reservation> findAllByRestaurantId(Long restaurantId);
 
 }

--- a/src/main/java/catchtable/cooking/persist/repository/WaitingRepository.java
+++ b/src/main/java/catchtable/cooking/persist/repository/WaitingRepository.java
@@ -1,14 +1,14 @@
 package catchtable.cooking.persist.repository;
 
-import catchtable.cooking.persist.domain.Review;
+import catchtable.cooking.persist.domain.Waiting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
-    List<Review> findAllByRestaurantId(Long restaurantId);
+    List<Waiting> findAllByRestaurantId(Long restaurantId);
 
 }

--- a/src/main/java/catchtable/cooking/service/ReviewService.java
+++ b/src/main/java/catchtable/cooking/service/ReviewService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -23,14 +22,6 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final RestaurantRepository restaurantRepository;
 
-    public List<Review> readReviews(Long id) {
-        Optional<Restaurant> restaurantEntity = restaurantRepository.findById(id);
-        if (restaurantEntity.isPresent() && restaurantEntity.get().getReviews() != null) {
-            return restaurantEntity.get().getReviews();
-        } else {
-            return null;
-        }
-    }
 
     public void createReview(Long id, ReviewCreateRequest reviewCreateRequest) {
         Optional<Restaurant> restaurant = restaurantRepository.findById(id);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#10 

## 📝 작업 내용

JPA 양방향 관계에서 다대일 단방향 관계로 변경했습니다. 그로 인해 기존에 작성된 API 코드들을 일부 수정했습니다. 

다대일 단방향 관계를 선택한 이유는 다음과 같습니다. 일대다 단방향 관계는 부모 엔티티(1측)가 자식 엔티티(N측)의 리스트를 갖고 있지만, 부모 엔티티가 자식 엔티티의 정보를 알 수 없습니다. 즉, 일대다 단방향 관계에서 자식 엔티티 데이터를 저장하게 되면 부모와의 관계에 영향을 받지 않고, 독립적으로 생성된다는 단점이 있습니다. 또한, 외래키가 다른 테이블에 존재하기 때문에 관리 측면에서도 쉽지 않다는 단점이 있습니다. 

이러한 단점을 피하기 위해서 ```다대일 단방향 관계``` 를 사용하기로 결정했습니다.


<br/>

## 💬 리뷰 요구사항

### # Q1 

불필요한 양방향 관계를 없애기 위해서 다대일 단방향 관계로 변경했습니다.  일부 API 코드를 수정하고, 식당 단건 조회를 해보았더니 다음과 같은 결과를 확인할 수 있었습니다.

![image](https://github.com/user-attachments/assets/e440b8f0-ab7b-4bb1-a776-53d2d3621793)


즉, 자식 엔티티에 부모 엔티티가 같이 포함되어 데이터를 반환하는 것을 확인하고, 다음과 같은 고민을 했습니다. 

- 부모 엔티티 정보가 담긴 데이터를 없앤 DTO를 사용할까 ?
- 자식 엔티티의 연관 관계를 가진 부모 엔티티 변수에 "JsonIgnore" 어노테이션을 사용하여 불필요한 데이터 중복을 없앨까? 

결국은 편리성을 위해서 JsonIgnore 어노테이션을 사용하여 불필요한 중복을 없앴는데, 이 방법이 좋은 방법인지 궁금합니다.

### # Q2
다대다 단방향 관계를 사용하니, 부모 엔티티(1측)에서 자식 엔티티(N측)의 정보를 get~~()로 불러올 수 없다는 불편함을 느꼈습니다. 그래서 다음과 같은 코드를 작성했습니다.

<img width="766" alt="image" src="https://github.com/user-attachments/assets/a3b2042b-f0b7-4611-8648-6bd351ffb1ef">

이런 방식이 올바른 방식인지 궁금합니다. 식당을 조회해야하는 모든 API 마다 저렇게 작성하는 것이 과연 옳을까? 라는 의문이 들지만, 이렇게 하지 않으면 어떻게 연관관계를 맞은 N측 데이터를 가지고 올 수 있을까 하는 의문이 사라지지 않고 있습니다!

### Q3
RequestBody로 받을 변수 중에 "phone_number"가 있습니다. 그러나 Java Entity 에서는 "phoneNumber"라고 선언했습니다. 평소에는 JsonProperty 어노테이션을 사용해서 이를 매칭시켜줬습니다. 소수의 컬럼에만 JsonProperty 어노테이션을 사용하는 것이 이쁘지 않아, 뭔가 전역적으로 처리해줄 수 있는 방법이 없을까 알아보았습니다. 다음과 같은 해결책을 yml 파일에 적용시켰습니다! 

<img width="390" alt="image" src="https://github.com/user-attachments/assets/0ea952a2-95a8-4800-8648-712623a66ae1">

현업에서 이와 같은 네이밍 설정 코드를 사용하는지 아니면 JsonProperty 어노테이션을 사용하는지 궁금합니다! 