### PR TITLE
[Feat] 로그인 기능 구현

### DIFF
--- a/src/main/java/catchtable/cooking/config/SecurityConfig.java
+++ b/src/main/java/catchtable/cooking/config/SecurityConfig.java
@@ -4,9 +4,13 @@ package catchtable.cooking.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
@@ -18,6 +22,26 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
+        // csrf disable
+        http.csrf(AbstractHttpConfigurer::disable);
 
+        // From 로그인 방식 disable
+        http.formLogin(AbstractHttpConfigurer::disable);
+
+        // http basic 인증 방식 disable
+        http.httpBasic(AbstractHttpConfigurer::disable);
+
+        // 경로별 인가 작업
+        http.authorizeHttpRequests((auth) -> auth
+                .requestMatchers("/api/**").permitAll());
+
+        // 세션 설정
+        http.sessionManagement((session) -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
 }

--- a/src/main/java/catchtable/cooking/config/WebConfig.java
+++ b/src/main/java/catchtable/cooking/config/WebConfig.java
@@ -1,0 +1,24 @@
+package catchtable.cooking.config;
+
+import catchtable.cooking.jwt.JwtTokenInterceptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final JwtTokenInterceptor jwtTokenInterceptor;
+
+    public void addInterceptors(InterceptorRegistry registry) {
+        log.info("Interceptor start");
+        registry.addInterceptor(jwtTokenInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/member/**");
+    }
+
+}

--- a/src/main/java/catchtable/cooking/controller/MemberController.java
+++ b/src/main/java/catchtable/cooking/controller/MemberController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -21,5 +22,18 @@ public class MemberController {
         memberService.register(new MemberCreateParam().of(memberRequest));
         return CommonResponse.of(Code.OK);
     }
+
+    @PostMapping("/api/member/login")
+    public CommonResponse<?> login(@RequestBody LoginRequest loginRequest) {
+        JwtToken jwtToken = memberService.authenticate(new LoginCreateParam().of(loginRequest));
+        return CommonResponse.of(jwtToken);
+    }
+
+    @PostMapping("/api/test")
+    public CommonResponse<?> test(@RequestHeader("Authorization") String token) {
+        log.info("token: {}", token);
+        return CommonResponse.of(token);
+    }
+
 
 }

--- a/src/main/java/catchtable/cooking/dto/Authentication.java
+++ b/src/main/java/catchtable/cooking/dto/Authentication.java
@@ -1,0 +1,27 @@
+package catchtable.cooking.dto;
+
+import catchtable.cooking.persist.domain.Member;
+import catchtable.cooking.persist.domain.MemberType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Authentication {
+
+    private String nickname;
+
+    private MemberType role;
+
+    public Authentication of(Member member) {
+        return Authentication.builder()
+                .nickname(member.getNickname())
+                .role(member.getRole())
+                .build();
+    }
+
+}

--- a/src/main/java/catchtable/cooking/dto/JwtToken.java
+++ b/src/main/java/catchtable/cooking/dto/JwtToken.java
@@ -1,0 +1,24 @@
+package catchtable.cooking.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JwtToken {
+
+    @JsonProperty("grant_type")
+    private String grantType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+}

--- a/src/main/java/catchtable/cooking/exception/Code.java
+++ b/src/main/java/catchtable/cooking/exception/Code.java
@@ -16,6 +16,8 @@ public enum Code {
     INVALID_LENGTH_PASSWORD(1003, "비밀번호는 8자 ~ 15자까지 가능합니다."),
     INVALID_PHONE_NUMBER(1004, "휴대폰 번호 형식이 잘못되었습니다."),
     ALREADY_EXIST_NICKNAME(1005, "이미 사용중인 닉네임입니다."),
+    NOT_EXIST_NICKNAME(1006, "존재하지 않는 닉네임입니다. 다시 입력해주세요."),
+    UNMATCHED_PASSWORD(1007, "비밀번호가 일치하지 않습니다."),
 
     // JWT Token Exception Code
     INVALID_ACCESS_TOKEN(2000, "잘못된 ACCESS_JWT 서명입니다."),

--- a/src/main/java/catchtable/cooking/jwt/JwtTokenInterceptor.java
+++ b/src/main/java/catchtable/cooking/jwt/JwtTokenInterceptor.java
@@ -1,0 +1,60 @@
+package catchtable.cooking.jwt;
+
+import catchtable.cooking.exception.Code;
+import catchtable.cooking.exception.CustomException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private static final String TOKEN_HEADER = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    public boolean preHandle(@NonNull HttpServletRequest request,
+                             @NonNull HttpServletResponse response,
+                             @NonNull Object handler) throws IOException {
+
+        String token = resolveToken(request);
+
+        log.info("access token: {}", token);
+        log.info("request: {}", request);
+
+        log.info("request path: {}", request.getServletPath());
+        log.info("request header: {}", request.getHeader("Authorization"));
+        log.info("request method: {}", request.getMethod());
+        log.info("request contentType: {}", request.getContentType());
+        log.info("request toString: {}", request.toString());
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            return true;
+        }
+        response.setStatus(401);
+        throw new CustomException(Code.ACCESS_TOKEN_UNAUTHORIZED);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        log.info("resolve 토큰 검증 request: {}", request);
+        String bearerToken = request.getHeader(TOKEN_HEADER);
+
+        log.info("resolve bearerToken: {}", bearerToken);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_PREFIX)) {
+            log.info("resolve 토큰 검증 완료!");
+            return bearerToken.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/catchtable/cooking/jwt/JwtTokenProvider.java
+++ b/src/main/java/catchtable/cooking/jwt/JwtTokenProvider.java
@@ -1,0 +1,121 @@
+package catchtable.cooking.jwt;
+
+import catchtable.cooking.dto.Authentication;
+import catchtable.cooking.dto.JwtToken;
+import catchtable.cooking.exception.Code;
+import catchtable.cooking.exception.CustomException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long TOKEN_EXPIRE_TIME = 1000 * 20;
+    private static final long TOKEN_REFRESH_TIME = 1000 * 60 * 60 * 4;
+    private final Key key;
+
+    //생성자를 통하여 KEY 값을 BASE64로 디코딩(해석)하고 해석한 값을
+    //SecretKey instance에 HMAC-SHA 로 암호화하여 초기화
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+        log.info("key 암호화 시도");
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        log.info("key 암호화 성공");
+    }
+
+    //권한 값을 인자로 받아와, 각각
+    public JwtToken generateToken(Authentication authentication) {
+        log.info("토큰 생성 시작");
+
+        Date now = new Date();
+        //만기 시간 설정
+        Date accessTokenExpiresIn = new Date(now.getTime() + TOKEN_EXPIRE_TIME);
+        Date refreshTokenExpiresIn = new Date(now.getTime() + TOKEN_REFRESH_TIME);
+
+        log.info("Access 토큰 생성 시작!");
+        /**
+         * Access Token 생성
+         *  header "alg" : "HS256"
+         *  payload "auth": "CUSTOMER || OWNER"
+         *  payload "sub": nickname
+         *  payload "iss": "cooking"
+         *  payload "iat": 토큰 발급 시간
+         *  payload "exp" : 토큰 만료 시간
+         */
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getNickname())
+                .claim("auth", authentication.getRole())
+                .setIssuer("cooking")
+                .setIssuedAt(now)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        log.info("Access 토큰 생성 완료!");
+        log.info("Refresh 토큰 생성 시작!");
+        String refreshToken = Jwts.builder()
+                .setIssuedAt(now)
+                .setExpiration(refreshTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        log.info("Refresh 토큰 생성 완료!");
+
+        return JwtToken.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // 토큰 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.", e);
+            throw new CustomException(Code.INVALID_ACCESS_TOKEN);
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.", e);
+            throw new CustomException(Code.EXPIRED_ACCESS_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.", e);
+            throw new CustomException(Code.UNSUPPORTED_ACCESS_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.", e);
+            throw new CustomException(Code.WRONG_TYPE_ACCESS_TOKEN);
+        }
+    }
+
+    //토큰을 claims로 변환하는 메서드
+    public Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public String getSubject(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#14 

## 📝 작업 내용

Spring Security를 사용하지 않고, 로그인 기능을 구현하였습니다. 
추가적으로 로그인 이후에 JWT 토큰의 유효성을 검증할 수 있는 기능을 구현했습니다.

- 로그인 기능 구현 
- 로그인 성공 이후 JWT 토큰을 발급하는 JwtTokenProvider 구현 
- Interceptor를 활용한 JWT 토큰 유효성 검증 및 예외 처리 

전체적인 로그인 플로우는 다음과 같습니다.
<br/>

![mermaid-diagram-2024-11-08-004405](https://github.com/user-attachments/assets/3a6b1830-b641-4c42-b13a-67b322472ead)





<br/>

## 💬 리뷰 요구사항
### # Q1 
클라이언트에서 서버로 JWT 토큰을 보낼 때, 토큰 정보가 Controller로 가기 전에 Interceptor에서 유효성 검증을 먼저 하게끔 구현해보았습니다. 이러한 구현 방식이 올바른 방식인지 궁금합니다.
